### PR TITLE
Explicitly calling out Git LFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # binary
-This is cross compile container.You can use it to compile the roller_eye project on the ubuntu host.  
-Follow these steps： 
 
-sudo apt-get install qemu-user-static  
-sudo git clone https://github.com/Pilot-Labs-Dev/binary.git  
-sudo tar -zxvf binary.tar.gz  
+This is cross compile container.You can use it to compile the roller_eye project on the ubuntu host.  
+Follow these steps：
+
+```bash
+sudo apt-get update && apt-get install git git-lfs qemu-user-static
+sudo git lfs clone --depth 1 https://github.com/Pilot-Labs-Dev/binary.git  
+sudo tar -zxvf ./binary/binary.tar.gz  
 sudo chroot binary  
 su linaro  
+```


### PR DESCRIPTION
Reason:
This repo uses Git LFS to store its binary file. Devs need to explicitly pull the file stored in LFS. Otherwise all you get is a pointer to the file which could be confusing for some.

Changes:
- requiring the installation of git and git-lfs (which is what the required Ubuntu version needs)
- cloning only one depth since full git history is not needed for Scout project setup
- also changing the tar path to match where it will live after the clone